### PR TITLE
Tailwind/Prettier: scan for "clsx" usages outside of "className"

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -8,3 +8,4 @@ semi: true
 singleQuote: true
 jsxSingleQuote: true
 bracketSpacing: false
+tailwindFunctions: ['clsx']

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@remotion/cli": "4.0.8",
         "@remotion/google-fonts": "4.0.8",
+        "clsx": "2.0.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "remotion": "4.0.8"
@@ -2793,6 +2794,14 @@
       "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@remotion/cli": "4.0.8",
     "@remotion/google-fonts": "4.0.8",
+    "clsx": "2.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "remotion": "4.0.8"


### PR DESCRIPTION
resolves: https://github.com/satelllte/remotion-template/issues/16